### PR TITLE
RFC: extend from \Contao\ModuleNewsList (+ other improvements)

### DIFF
--- a/src/Resources/contao/dca/tl_module.php
+++ b/src/Resources/contao/dca/tl_module.php
@@ -11,13 +11,8 @@
  */
 
 
-/**
- * Add palettes to tl_module
- */
-$GLOBALS['TL_DCA']['tl_module']['palettes']['newslist_infinite_scroll'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['newslist'];
-
-
 $GLOBALS['TL_DCA']['tl_module']['config']['onload_callback'][] = array('tl_module_contao_news_infinite_scroll', 'showJsLibraryHint');
+$GLOBALS['TL_DCA']['tl_module']['config']['onload_callback'][] = array('tl_module_contao_news_infinite_scroll', 'setPalette');
 
 
 /**
@@ -25,7 +20,7 @@ $GLOBALS['TL_DCA']['tl_module']['config']['onload_callback'][] = array('tl_modul
  *
  * @author Marko Cupic <https://github.com/markocupic>
  */
-class tl_module_contao_news_infinite_scroll extends Backend
+class tl_module_contao_news_infinite_scroll extends \Contao\Backend
 {
 
     /**
@@ -55,7 +50,7 @@ class tl_module_contao_news_infinite_scroll extends Backend
             return;
         }
 
-        $objMod = ModuleModel::findByPk($dc->id);
+        $objMod = \Contao\ModuleModel::findByPk($dc->id);
 
         if ($objMod === null)
         {
@@ -64,8 +59,16 @@ class tl_module_contao_news_infinite_scroll extends Backend
 
         if ($objMod->type == 'newslist_infinite_scroll')
         {
-            Message::addInfo(sprintf($GLOBALS['TL_LANG']['tl_module']['includeContaoNewsInfiniteScrollTemplate'], 'j_news_infinite_scroll'));
+            \Contao\Message::addInfo(sprintf($GLOBALS['TL_LANG']['tl_module']['includeContaoNewsInfiniteScrollTemplate'], 'j_news_infinite_scroll'));
 
         }
+    }
+
+    /**
+     * Sets the newslist_infinite_scroll palette as late as possible.
+     */
+    public function setPalette()
+    {
+        $GLOBALS['TL_DCA']['tl_module']['palettes']['newslist_infinite_scroll'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['newslist'];
     }
 }

--- a/src/Resources/contao/modules/ModuleNewslistInfiniteScroll.php
+++ b/src/Resources/contao/modules/ModuleNewslistInfiniteScroll.php
@@ -12,19 +12,10 @@
 
 namespace Markocupic;
 
-
 use Contao\BackendTemplate;
-use Contao\Config;
-use Contao\CoreBundle\Exception\PageNotFoundException;
 use Contao\Environment;
-use Contao\Input;
-use Contao\Model\Collection;
 use Contao\ModuleNewsList;
-use Contao\NewsModel;
-use Contao\Pagination;
-use Contao\System;
 use Patchwork\Utf8;
-
 
 /**
  * Display Infinite Scroll Newslist Module
@@ -34,14 +25,6 @@ use Patchwork\Utf8;
  */
 class ModuleNewslistInfiniteScroll extends ModuleNewsList
 {
-
-    /**
-     * Template
-     * @var string
-     */
-    protected $strTemplate = 'mod_newslist';
-
-
     /**
      * Display a wildcard in the back end
      *
@@ -80,92 +63,7 @@ class ModuleNewslistInfiniteScroll extends ModuleNewsList
      */
     protected function compile()
     {
-        $limit = null;
-        $offset = (int) $this->skipFirst;
-
-        // Maximum number of items
-        if ($this->numberOfItems > 0)
-        {
-            $limit = $this->numberOfItems;
-        }
-
-        // Handle featured news
-        if ($this->news_featured == 'featured')
-        {
-            $blnFeatured = true;
-        }
-        elseif ($this->news_featured == 'unfeatured')
-        {
-            $blnFeatured = false;
-        }
-        else
-        {
-            $blnFeatured = null;
-        }
-
-        $this->Template->articles = array();
-        $this->Template->empty = $GLOBALS['TL_LANG']['MSC']['emptyList'];
-
-        // Get the total number of items
-        $intTotal = $this->countItems($this->news_archives, $blnFeatured);
-
-        if ($intTotal < 1)
-        {
-            return;
-        }
-
-        $total = $intTotal - $offset;
-
-        // Split the results
-        if ($this->perPage > 0 && (!isset($limit) || $this->numberOfItems > $this->perPage))
-        {
-            // Adjust the overall limit
-            if (isset($limit))
-            {
-                $total = min($limit, $total);
-            }
-
-            // Get the current page
-            $id = 'page_n' . $this->id;
-            $page = (Input::get($id) !== null) ? Input::get($id) : 1;
-
-            // Prevent duplicate content by adding the canonical url into the head
-            if (Input::get($id) !== null)
-            {
-                $GLOBALS['TL_HEAD'][] = '<link rel="canonical" href="' . Environment::get('url') . '/' . str_replace('?' . Environment::get('queryString'), '', Environment::get('request')) . '" />';
-            }
-
-            // Do not index or cache the page if the page number is outside the range
-            if ($page < 1 || $page > max(ceil($total / $this->perPage), 1))
-            {
-                throw new PageNotFoundException('Page not found: ' . Environment::get('uri'));
-            }
-
-            // Set limit and offset
-            $limit = $this->perPage;
-            $offset += (max($page, 1) - 1) * $this->perPage;
-            $skip = (int) $this->skipFirst;
-
-            // Overall limit
-            if ($offset + $limit > $total + $skip)
-            {
-                $limit = $total + $skip - $offset;
-            }
-
-            // Add the pagination menu
-            $objPagination = new Pagination($total, $this->perPage, Config::get('maxPaginationLinks'), $id);
-            $this->Template->pagination = $objPagination->generate("\n  ");
-        }
-
-        $objArticles = $this->fetchItems($this->news_archives, $blnFeatured, ($limit ?: 0), $offset);
-
-        // Add the articles
-        if ($objArticles !== null)
-        {
-            $this->Template->articles = $this->parseArticles($objArticles);
-        }
-
-        $this->Template->archives = $this->news_archives;
+        parent::compile();
 
         // Add Css Class
         $this->Template->cssID[1] = $this->Template->cssID[1] == '' ? 'ajaxCall' : $this->Template->cssID[1] . ' ajaxCall';
@@ -180,100 +78,5 @@ class ModuleNewslistInfiniteScroll extends ModuleNewsList
             $this->Template->output();
             exit();
         }
-    }
-
-
-    /**
-     * Count the total matching items
-     *
-     * @param array $newsArchives
-     * @param boolean $blnFeatured
-     *
-     * @return integer
-     */
-    protected function countItems($newsArchives, $blnFeatured)
-    {
-        // HOOK: add custom logic
-        if (isset($GLOBALS['TL_HOOKS']['newsListCountItems']) && \is_array($GLOBALS['TL_HOOKS']['newsListCountItems']))
-        {
-            foreach ($GLOBALS['TL_HOOKS']['newsListCountItems'] as $callback)
-            {
-                if (($intResult = System::importStatic($callback[0])->{$callback[1]}($newsArchives, $blnFeatured, $this)) === false)
-                {
-                    continue;
-                }
-
-                if (\is_int($intResult))
-                {
-                    return $intResult;
-                }
-            }
-        }
-
-        return NewsModel::countPublishedByPids($newsArchives, $blnFeatured);
-    }
-
-
-    /**
-     * Fetch the matching items
-     *
-     * @param  array $newsArchives
-     * @param  boolean $blnFeatured
-     * @param  integer $limit
-     * @param  integer $offset
-     *
-     * @return Collection|NewsModel|null
-     */
-    protected function fetchItems($newsArchives, $blnFeatured, $limit, $offset)
-    {
-        // HOOK: add custom logic
-        if (isset($GLOBALS['TL_HOOKS']['newsListFetchItems']) && \is_array($GLOBALS['TL_HOOKS']['newsListFetchItems']))
-        {
-            foreach ($GLOBALS['TL_HOOKS']['newsListFetchItems'] as $callback)
-            {
-                if (($objCollection = System::importStatic($callback[0])->{$callback[1]}($newsArchives, $blnFeatured, $limit, $offset, $this)) === false)
-                {
-                    continue;
-                }
-
-                if ($objCollection === null || $objCollection instanceof Collection)
-                {
-                    return $objCollection;
-                }
-            }
-        }
-
-        // Determine sorting
-        $t = NewsModel::getTable();
-        $order = '';
-
-        if ($this->news_featured == 'featured_first')
-        {
-            $order .= "$t.featured DESC, ";
-        }
-
-        switch ($this->news_order)
-        {
-            case 'order_headline_asc':
-                $order .= "$t.headline";
-                break;
-
-            case 'order_headline_desc':
-                $order .= "$t.headline DESC";
-                break;
-
-            case 'order_random':
-                $order .= "RAND()";
-                break;
-
-            case 'order_date_asc':
-                $order .= "$t.date";
-                break;
-
-            default:
-                $order .= "$t.date DESC";
-        }
-
-        return NewsModel::findPublishedByPids($newsArchives, $blnFeatured, $limit, $offset, ['order'=>$order]);
     }
 }


### PR DESCRIPTION
Currently, your newslist module does not extend from `\Contao\ModuleNewsList`. This leads to problems with the `newsListFetchItems` hook for example, as other app or extension developers will expect a `\Contao\ModuleNewsList` object as the passed parameter.

Furthermore, by extending from the existing `\Contao\ModuleNewsList`, you can reuse the majority of its functionality and only add the functionality that you actually need. Thus if there are any changes or improvements in the `contao/news-bundle`, your own module will automatically benefit from that.

Also, to make this extension even more compatible with other existing newslist extensions, the palette can be changed via an `onload_callback` instead. This way, any changes to the original `newslist` palette will be transported over to the `newslist_infinite_scroll` palette.

_However,_ this PR also removes the canonical tag functionality. Imho this should be part of a different extension, as this does not really have anything to do with the infinite scrolling functionality? And it should be implemented via a hook instead. Since this a backwards compatibility break, I labelled this PR as RFC, to discuss things further.